### PR TITLE
Add pages to proposition list

### DIFF
--- a/src/ekklesia_portal/concepts/proposition/proposition_cells.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_cells.py
@@ -1,4 +1,5 @@
 import urllib.parse
+import math
 from operator import attrgetter
 from secrets import compare_digest
 
@@ -414,6 +415,23 @@ class PropositionsCell(LayoutCell):
     def propositions(self):
         is_admin = self.current_user and self._request.identity.has_global_admin_permissions
         return list(self._model.propositions(self._request.q, is_admin))
+
+    def prop_count(self):
+        is_admin = self.current_user and self._request.identity.has_global_admin_permissions
+        return self._model.propositions(self._request.q, is_admin, count=True)
+
+    def page_count(self):
+        per_page = self.prop_per_page
+        if per_page <= 0:
+            return -1
+        else:
+            return int(math.ceil(self.prop_count / per_page))
+
+    def prop_per_page(self):
+        return self._model.propositions_per_page()
+
+    def page(self):
+        return self._model.page or 1
 
     # Overrides the base method in LayoutCell
     def search_query(self):

--- a/src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade
@@ -132,6 +132,62 @@
   else
     = _('no_propositions_found')
 
+  div.page-selector
+    if propositions
+      div.prop-count
+        if prop_per_page < 0
+          = _("showing_all_propositions", count=prop_count)
+        else
+          = _("showing_x_propositions", from=(page-1)*prop_per_page+1, to=[page*prop_per_page, prop_count] | min, count=prop_count)
+
+    if page_count > 1
+      ul
+        if page > 1
+          li
+            a.page_btn(href=change_self_link(page=1), title=_('first_page'))
+              = "<<"
+          li
+            a.page_btn(href=change_self_link(page=page-1), title=_('previous_page'))
+              = "<"
+
+        for page_nr in range([1, page-4] | max, [page_count+1, page+4] | min)
+          li
+            if page_nr == page
+              span.page_btn.disabled
+                = (page_nr)
+            else
+              a.page_btn(href=change_self_link(page=page_nr))
+                = (page_nr)
+
+        if page < page_count
+          li
+            a.page_btn(href=change_self_link(page=page+1), title=_('next_page'))
+              = ">"
+          li
+            a.page_btn(href=change_self_link(page=page_count), title=_('last_page'))
+              = ">>"
+
+    form
+      if search_query
+        input(type="hidden",name="search",value=search_query)
+      if sort
+        input(type="hidden",name="sort",value=sort)
+
+      select(name="per_page",autocomplete="off",onchange="this.form.submit()")
+        if prop_per_page > 0 and prop_per_page not in [5, 10, 20, 50]
+          option(selected=true, value=prop_per_page)
+            = prop_per_page
+
+        for amount in [5, 10, 20, 50]
+          option(selected=(prop_per_page==amount), value=amount)
+            = amount
+        option(selected=(prop_per_page < 0), value="-1")
+          = _("all_pages")
+
+      = _("per_page")
+      input(type="submit", value=_("set_page_count"), id="submit_page_count")
+      script
+        = "document.getElementById('submit_page_count').style.display = 'none';" | safe
 
 // generated from jade
 //- vim: set filetype=jade sw=2 ts=2 sts=2 expandtab:

--- a/src/ekklesia_portal/sass/portal.sass
+++ b/src/ekklesia_portal/sass/portal.sass
@@ -285,6 +285,50 @@ ul.proposition_filter
     @extend .badge-light
     font-size: 1rem
 
+.page-selector
+  margin-top: 2rem
+  margin-bottom: 2rem
+  text-align: center
+
+  .prop-count
+    margin-bottom: 0.5rem
+
+  ul
+    padding: 0
+    margin: 0 0 0.5rem
+
+    li
+      display: inline-block
+
+  .page_btn
+    @extend .btn
+    @extend .btn-secondary
+
+  form
+    font-size: 0.9rem
+
+    select
+      -moz-appearance: none /* Firefox */
+      -webkit-appearance: none /* Safari and Chrome */
+      appearance: none
+      background: transparent
+      background-image: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>")
+      background-repeat: no-repeat
+      background-position-x: 100%
+      background-position-y: 0.1rem
+      border: 1px solid #ced4da
+      border-radius: 0.25rem
+      padding: 0.1rem 0.3rem
+      width: 3.5rem
+      vertical-align: middle
+
+    select:hover
+      box-shadow: inset 0 0 10px -4px gray
+
+    input
+      @extend .btn
+      @extend .btn-secondary
+      @extend .btn-sm
 
 .search_button
   @extend .btn

--- a/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
@@ -844,6 +844,42 @@ msgstr "Anträge ohne Tags"
 msgid "no_propositions_found"
 msgstr "Keine Anträge gefunden"
 
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:147
+msgid "first_page"
+msgstr "Erste Seite"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:150
+msgid "previous_page"
+msgstr "Vorherige Seite"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:164
+msgid "next_page"
+msgstr "Nächste Seite"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:167
+msgid "last_page"
+msgstr "Letzte Seite"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:187
+msgid "per_page"
+msgstr " pro Seite"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:185
+msgid "all_pages"
+msgstr "Alle"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:188
+msgid "set_page_count"
+msgstr "Setzen"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:139
+msgid "showing_all_propositions"
+msgstr "Alle %(count)s Anträge werden angezeigt"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:141
+msgid "showing_x_propositions"
+msgstr "Anträge %(from)s - %(to)s von %(count)s"
+
 #: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:1
 msgid "title_draft"
 msgstr "Neuer Antragsentwurf"

--- a/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
@@ -840,6 +840,42 @@ msgstr "Propositions without tags"
 msgid "no_propositions_found"
 msgstr "No propositions found"
 
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:147
+msgid "first_page"
+msgstr "First page"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:150
+msgid "previous_page"
+msgstr "Previous page"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:164
+msgid "next_page"
+msgstr "Next page"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:167
+msgid "last_page"
+msgstr "Last page"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:187
+msgid "per_page"
+msgstr " per page"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:185
+msgid "all_pages"
+msgstr "All"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:188
+msgid "set_page_count"
+msgstr "Set"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:139
+msgid "showing_all_propositions"
+msgstr "Showing all %(count)s propositions"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:141
+msgid "showing_x_propositions"
+msgstr "Propositions %(from)s - %(to)s of %(count)s"
+
 #: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:1
 msgid "title_draft"
 msgstr "New Draft"


### PR DESCRIPTION
This adds a page system to the proposition list.

The url parameters `page` and `per_page` are used to control the settings.
Setting `per_page` to -1 displays all propositions on one page.
The default of 0 for `per_page` falls back to showing 20 propositions per page.

At the bottom of the proposition list, the following UI elements were added:
- A text message describing the currently shown propositions
- The page selector containing buttons for the first and last, previous and next as well as the previous and next three pages.
- A dropdown selector for the number of propositions per page

TODO: Tests