### PR TITLE
Fix without tags filter when multiple pages are displayed

### DIFF
--- a/src/ekklesia_portal/concepts/proposition/propositions.py
+++ b/src/ekklesia_portal/concepts/proposition/propositions.py
@@ -267,8 +267,9 @@ class Propositions:
         propositions = propositions.order_by(Proposition.voting_identifier, Proposition.title)
 
         if self.without_tag_values:
-            tags = set(q(Tag).filter(func.lower(Tag.name).in_(self.without_tag_values)).all())
-            propositions = (p for p in propositions if not tags & set(p.tags))
+            tags = q(Tag).filter(func.lower(Tag.name).in_(self.without_tag_values)).all()
+            for tag in tags:
+                propositions = propositions.filter(~Proposition.tags.contains(tag))
 
         if count:
             propositions = propositions.count()

--- a/tests/concepts/proposition/test_propositions.py
+++ b/tests/concepts/proposition/test_propositions.py
@@ -39,6 +39,14 @@ def test_index_tag(db_query, client):
     assert 'Ein Titel' in res
 
 
+def test_index_without_tags(db_query, client):
+    """XXX: depends on content from create_test_db.py"""
+    res = client.get('/p?without_tags=Tag1')
+    assert 'Ein Titel' not in res
+    assert 'Änderungsantrag zu PP001' in res
+    assert 'Entstehender Antrag' in res
+
+
 def test_index_status(client):
     """XXX: depends on content from create_test_db.py"""
     res = client.get('/p?status=abandoned')


### PR DESCRIPTION
Now applies the without_tags filter using the ORM model instead of Python code.
Also adds a test case for this filter.