### PR TITLE
UI fixes

### DIFF
--- a/src/ekklesia_portal/concepts/ekklesia_portal/templates/layout.j2.jade
+++ b/src/ekklesia_portal/concepts/ekklesia_portal/templates/layout.j2.jade
@@ -20,8 +20,8 @@ body
       a.navbar-brand(href='/')= brand_title
 
       form.top_lang_controls(action=change_language_action, method='POST')
+        input(type="hidden",name="back_url",value=page_url)
         .btn-group
-          input(type="hidden",name="back_url",value=page_url)
           for mylang in settings_languages
             button.lang_select_button(type="submit", name="lang", value=mylang, class=("active" if language == mylang))
               span=mylang.upper()

--- a/src/ekklesia_portal/concepts/proposition/proposition_cells.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_cells.py
@@ -246,6 +246,12 @@ class PropositionCell(LayoutCell):
             PropositionStatus.VOTING, PropositionStatus.ABANDONED
         ) and self._request.permitted_for_current_user(ArgumentRelations(), CreatePermission)
 
+    def show_goto_arguments(self):
+        return self._model.status in (
+            PropositionStatus.SUBMITTED, PropositionStatus.QUALIFIED, PropositionStatus.SCHEDULED,
+            PropositionStatus.VOTING, PropositionStatus.ABANDONED
+        )
+
     def show_create_associated_proposition(self):
         return self._model.status in (
             PropositionStatus.DRAFT, PropositionStatus.SUBMITTED, PropositionStatus.QUALIFIED,

--- a/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade
@@ -20,12 +20,6 @@ else
     p
       a(href=become_submitter_url)= become_submitter_url
 
-  if show_submitter_names and submitter_names
-    p= _('current_submitters')
-    ul
-      for name in submitter_names
-        li= name
-
   if valid_submitter_invitation_key and not current_user_is_submitter
     p = _('invited_to_become_submitter')
 
@@ -39,3 +33,8 @@ else
       p
         a(href=login_url)= _('notice_login')
 
+if show_submitter_names and submitter_names
+  p= _('current_submitters')
+  ul
+    for name in submitter_names
+      li= name

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade
@@ -4,4 +4,7 @@ if show_full_history
       = _("created_by", author=author.name)
 
 .proposition_history_item
-  = _("created_on", date=created_at|dateformat)
+  if created_at
+    = _("created_on", date=created_at|dateformat)
+  else
+    = _("created_no_date")

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade
@@ -3,11 +3,16 @@ if show_full_history
     .proposition_history_item
       = _("created_by", author=author.name)
 
-  .proposition_history_item
-    = _("created_on", date=created_at|dateformat)
+  if created_at
+    .proposition_history_item
+      = _("created_on", date=created_at|dateformat)
 
-  .proposition_history_item
-    = _('submitted_on', date=submitted_at|dateformat)
+  if submitted_at
+    .proposition_history_item
+      = _('submitted_on', date=submitted_at|dateformat)
 
 .proposition_history_item
-  = _('finished_on', date=voting_phase.target|dateformat)
+  if voting_phase.target
+    = _('finished_on', date=voting_phase.target|dateformat)
+  else
+    = _('finished_no_date')

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade
@@ -3,8 +3,9 @@ if show_full_history
     .proposition_history_item
       = _("created_by", author=author.name)
 
-  .proposition_history_item
-    = _("created_on", date=created_at|dateformat)
+  if created_at
+    .proposition_history_item
+      = _("created_on", date=created_at|dateformat)
 
   if submitted_at
     .proposition_history_item
@@ -14,6 +15,8 @@ if show_full_history
     .proposition_history_item
       = _('qualified_on', date=qualified_at|dateformat)
 
-if voting_phase.target
-  .proposition_history_item
+.proposition_history_item
+  if voting_phase.target
     = _('voting_ends_at', datetime=voting_phase.target|datetimeformat)
+  else
+    = _('voting_no_date')

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade
@@ -3,8 +3,12 @@ if show_full_history
     .proposition_history_item
       = _("created_by", author=author.name)
 
-  .proposition_history_item
-    = _("created_on", date=created_at|dateformat)
+  if created_at
+    .proposition_history_item
+      = _("created_on", date=created_at|dateformat)
 
 .proposition_history_item
-  = _('submitted_on', date=submitted_at|dateformat)
+  if submitted_at
+    = _('submitted_on', date=submitted_at|dateformat)
+  else
+    = _('submitted_no_date')

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade
@@ -14,7 +14,7 @@
       if secret_voting
         button.btn.btn-primary.btn-sm(type="submit", name="public_voting")
           i.far.fa-eye-slash &nbsp;
-          = _('button_secret_voting') 
+          = _('button_secret_voting')
           = ' ('
           abbr(title= _('abbr_secret_voters_count'))
             = secret_voters_count
@@ -25,7 +25,7 @@
        else
         button.btn.btn-secondary.btn-sm(type="submit", name="secret_voting")
           i.far.fa-eye &nbsp;
-          = _('button_public_voting') 
+          = _('button_public_voting')
           = ' ('
           abbr(title= _('abbr_secret_voters_count'))
             = secret_voters_count
@@ -48,21 +48,23 @@
       i.fas.fa-external-link-alt &nbsp;
       = _('button_external_discussion_url')
 
-  a.btn.btn-secondary.btn-sm(href="#bottom")
-    i.far.fa-comments &nbsp;
-    if options.active_tab == 'discussion'
-      = _("button_goto_arguments")
-    else
-      = _("button_goto_associated")
+  if show_goto_arguments:
+    a.btn.btn-secondary.btn-sm(href="#bottom")
+      i.far.fa-comments &nbsp;
+      if options.active_tab == 'discussion'
+        = _("button_goto_arguments")
+      else
+        = _("button_goto_associated")
 
   if report_url
     a.btn.btn-sm(href=report_url)
       i.fas.fa-flag &nbsp;
       = _('button_report')
 
-  a.btn.btn-secondary.btn-sm(href=note_url)
-    i.fas.fa-notes-medical &nbsp;
-    = _('note_button')
+  if note_url
+    a.btn.btn-secondary.btn-sm(href=note_url)
+      i.fas.fa-notes-medical &nbsp;
+      = _('note_button')
 
   if show_edit_button
     a.btn.btn-secondary.btn-sm(href=edit_url)

--- a/src/ekklesia_portal/sass/portal.sass
+++ b/src/ekklesia_portal/sass/portal.sass
@@ -6,6 +6,13 @@
 @import font-awesome/brands
 @import custom
 
+html
+  height: 100%
+
+body
+  min-height: 100%
+  position: relative
+
 $light-orange: lighten($orange, 15%)
 
 .alert_message
@@ -136,6 +143,8 @@ $light-orange: lighten($orange, 15%)
 .content_area
   @extend .container
   @extend .my-2
+  padding-bottom: 3rem
+  margin-bottom: 0 !important
 
 .proposition-body
   @extend .card-body
@@ -157,6 +166,12 @@ $light-orange: lighten($orange, 15%)
 footer.footer
   @extend .bg-primary
   @extend .p-2
+
+  position: absolute
+  bottom: 0
+  left: 0
+  right: 0
+  height: 3em
 
   .list-inline
     @extend .my-1

--- a/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
@@ -1037,15 +1037,27 @@ msgstr "Du unterstützt diesen Antrag."
 msgid "created_by"
 msgstr "Erstellt von %(author)s"
 
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:10
+msgid "created_no_date"
+msgstr "Entwurf erstellt"
+
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:6
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:6
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:6
 msgid "submitted_on"
 msgstr "Eingereicht am %(date)s"
 
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:15
+msgid "submitted_no_date"
+msgstr "Eingereicht"
+
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:8
 msgid "finished_on"
 msgstr "Abgeschlossen am %(date)s"
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:19
+msgid "finished_no_date"
+msgstr "Abgeschlossen"
 
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:8
 msgid "qualified_on"
@@ -1054,6 +1066,10 @@ msgstr "Zur Abstimmung qualifiziert am %(date)s"
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:10
 msgid "voting_ends_at"
 msgstr "Abstimmung endet um %(datetime)s"
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:22
+msgid "voting_no_date"
+msgstr "Wird abgestimmt"
 
 #: src/ekklesia_portal/concepts/proposition/templates/status/proposition_status_draft.j2.jade:1
 msgid "working_draft"

--- a/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
@@ -1027,15 +1027,27 @@ msgstr "You support this proposition."
 msgid "created_by"
 msgstr "Created by %(author)s"
 
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:10
+msgid "created_no_date"
+msgstr "Draft created"
+
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:6
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:6
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:6
 msgid "submitted_on"
 msgstr "Submitted on %(date)s"
 
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:15
+msgid "submitted_no_date"
+msgstr "Submitted"
+
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:8
 msgid "finished_on"
 msgstr "Finished on %(date)s"
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:19
+msgid "finished_no_date"
+msgstr "Finished"
 
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:8
 msgid "qualified_on"
@@ -1044,6 +1056,10 @@ msgstr "Qualified for voting on %(date)s"
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:10
 msgid "voting_ends_at"
 msgstr "Voting ends at %(datetime)s"
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:22
+msgid "voting_no_date"
+msgstr "In voting"
 
 #: src/ekklesia_portal/concepts/proposition/templates/status/proposition_status_draft.j2.jade:1
 msgid "working_draft"


### PR DESCRIPTION
This pr fixes multiple small issues:
- Fix round corners of the language switch icons
- Show "Go to arguments" button only if arguments are enabled (not in draft mode)
- Show submitters in all stages of a draft if allowed to see them
- Move footer to the bottom even if the page is shorter
- Hide "Notes" button if user not logged in
- If a specific date is not set, show the text without a date instead of defaulting to the current date (Fixes #69)