### PR TITLE
Improve VVVote integration

### DIFF
--- a/src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade
+++ b/src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade
@@ -14,7 +14,7 @@
 
   .voting_phase.container
     if options.full_view
-      h2= phase_type.name
+      h2= title or phase_type.name
         if show_edit_button
           a.edit_button(href=edit_url)
             i.far.fa-edit
@@ -48,23 +48,36 @@
                   i.fas.fa-times &nbsp;
                   = _("could_not_vote_currently")
 
+          if show_voting_without_url
+            p.help-text.mb-2= _("voting_info_text", end=voting_end|datetimeformat)
+
           if show_registration
-
             p.help-text.mb-2= _("registration_links_help_text", end=registration_end|datetimeformat)
-
             ul.votings
-              for title, url in votings
-                li
-                  a(href=url)= _("register_now_with_voting_module", title=title)
+            for title, url in votings
+              li
+                a.btn.btn-primary.btn-sm(href=url)
+                  i.fas.fa-sign-in-alt &nbsp;
+                  = _('register_now_with_voting_module', title=title)
 
-          if show_voting
-
+          if show_voting_with_url
             p.help-text.mb-2= _("voting_links_help_text", end=voting_end|datetimeformat)
-
             ul.votings
               for title, url in votings
                 li
-                  a(href=url)= _("vote_now_with_voting_module", title=title)
+                  a.btn.btn-primary.btn-sm(href=url)
+                    i.fas.fa-person-booth &nbsp;
+                    = _('vote_now_with_voting_module', title=title)
+
+          if show_result_link
+            p.help-text.mb-2= _("result_links_help_text")
+            ul.votings
+              for title, url in voting_results
+                li
+                  a.btn.btn-secondary.btn-sm(href=url)
+                    i.fas.fa-poll-h &nbsp;
+                    = _('show_results_with_voting_module', title=title)
+
           hr
 
         .row

--- a/src/ekklesia_portal/concepts/voting_phase/voting_phase_views.py
+++ b/src/ekklesia_portal/concepts/voting_phase/voting_phase_views.py
@@ -160,7 +160,7 @@ def create_voting(self, request):
 
     with start_action(action_type="create_election_in_vvvote", election_config=election_config) as action:
         config_url = create_election_in_vvvote(module_config, election_config)
-        self.voting_module_data[voting_module_name] = {"config_url": config_url}
+        self.voting_module_data[voting_module_name] = {"config_url": config_url, "results_url": config_url + "&showresult"}
         action.add_success_fields(config_url=config_url)
 
     _ = request.i18n.gettext

--- a/src/ekklesia_portal/lib/vvvote/election_config.py
+++ b/src/ekklesia_portal/lib/vvvote/election_config.py
@@ -1,4 +1,3 @@
-import datetime
 from uuid import uuid4
 
 import ekklesia_portal.lib.vvvote.schema as vvvote_schema
@@ -15,7 +14,7 @@ def ballot_to_vvvote_question(ballot, question_id=1):
     voting_scheme = [voting_scheme_yes_no, voting_scheme_score]
 
     for option_id, proposition in enumerate(ballot.propositions, start=1):
-        proponents = [s.name for s in proposition.supporters]
+        proponents = [s.member.name for s in proposition.propositions_member if s.submitter]
         option = vvvote_schema.Option(
             optionID=option_id,
             proponents=proponents,

--- a/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
@@ -1093,7 +1093,7 @@ msgstr "Zur Abstimmung qualifiziert am %(date)s"
 
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:10
 msgid "voting_ends_at"
-msgstr "Abstimmung endet um %(datetime)s"
+msgstr "Abstimmung endet am %(datetime)s"
 
 #: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:10
 msgid "voting_no_date"
@@ -1339,11 +1339,11 @@ msgstr ""
 
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:22
 msgid "could_vote_currently"
-msgstr "Du wirst an der Abstimmung teilnehmen können nach aktuellem Stand."
+msgstr "Du wirst nach aktuellem Stand an der Abstimmung teilnehmen können."
 
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:22
 msgid "could_not_vote_currently"
-msgstr "Du wirst nicht an der Abstimmung teilnehmen können nach aktuellem Stand."
+msgstr "Du wirst nach aktuellem Stand nicht an der Abstimmung teilnehmen können."
 
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:24
 msgid "registration_links_help_text"
@@ -1355,13 +1355,25 @@ msgstr ""
 msgid "register_now_with_voting_module"
 msgstr "Jetzt registrieren bei %(title)s"
 
+#: rc/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:61
+msgid "voting_info_text"
+msgstr "Die Abstimmung läuft aktuell bis zum %(end)s. Nutze das bei der Registrierung erzeugte Dokument zur Abstimmung."
+
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:29
 msgid "voting_links_help_text"
-msgstr "Stimme ab bis %(end)s."
+msgstr "Du kannst bis %(end)s abstimmen."
 
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:31
 msgid "vote_now_with_voting_module"
 msgstr "Stimme jetzt ab bei %(title)s"
+
+#: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:71
+msgid "result_links_help_text"
+msgstr "Die Abstimmung ist beendet und die Ergebnisse und können eingesehen werden"
+
+#: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:77
+msgid "show_results_with_voting_module"
+msgstr "Ergebnisse bei %(title)s ansehen"
 
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:45
 msgid "registration_from"

--- a/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
@@ -1340,6 +1340,10 @@ msgstr ""
 msgid "register_now_with_voting_module"
 msgstr "Register now at %(title)s"
 
+#: rc/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:61
+msgid "voting_info_text"
+msgstr "The voting runs until %(end)s. Use the document created during the registration to vote."
+
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:29
 msgid "voting_links_help_text"
 msgstr "Cast your vote until %(end)s."
@@ -1347,6 +1351,14 @@ msgstr "Cast your vote until %(end)s."
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:31
 msgid "vote_now_with_voting_module"
 msgstr "Vote now at %(title)s"
+
+#: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:71
+msgid "result_links_help_text"
+msgstr "The voting has finished. The results can be viewed."
+
+#: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:77
+msgid "show_results_with_voting_module"
+msgstr "View results at %(title)s"
 
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:45
 msgid "registration_from"


### PR DESCRIPTION
- Set submitted_at and qualified_at even when skipping a state from the admin interface
- Fix draft submission when using no importer
- Show phase title instead of type as page header on voting phase page
- Improve voting phase view with external voting system
  - Show information during voting even after a registration phase
  - Display voting/registration links as a button
  - Show a link to the results after the voting has ended
  - Store results link in voting module data json array (for VVVote: Add &showresult to the URL)
- Send submitter list to VVVote instead of supporters
- Improve some texts