### PR TITLE
Proposition: show department and area as badges

### DIFF
--- a/src/ekklesia_portal/concepts/proposition/proposition_cells.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_cells.py
@@ -58,7 +58,7 @@ class PropositionCell(LayoutCell):
     secret_voting = Cell.template_fragment('proposition_secret_voting')
     support = Cell.template_fragment('proposition_support')
     toolbar = Cell.fragment('proposition_toolbar')
-    tag_list = Cell.fragment('proposition_tag_list')
+    badges = Cell.fragment('proposition_badges')
     small = Cell.fragment('proposition_small')
     card = Cell.fragment('proposition_card')
 
@@ -102,6 +102,12 @@ class PropositionCell(LayoutCell):
             return ""
         template = f"proposition/detail_top/proposition_detail_top_{variant}.j2.jade"
         return self.render_template(template)
+
+    def department_name(self):
+        return self._model.ballot.area.department.name
+
+    def subject_area_name(self):
+        return self._model.ballot.area.name
 
     def associated_url(self):
         return self.link(self._model, 'associated')
@@ -161,8 +167,16 @@ class PropositionCell(LayoutCell):
     def discussion_url(self):
         return self.link(self._model)
 
-    def propositions_tag_url(self, tag):
-        return self.class_link(Propositions, dict(tags=tag.name))
+    def propositions_badge_url(self, department_name, subject_area_name=None, tag_name=None):
+        params = {"department": department_name}
+
+        if subject_area_name:
+            params["subject_area"] = subject_area_name
+
+        if tag_name:
+            params["tags"] = tag_name
+
+        return self.class_link(Propositions, params)
 
     def current_user_is_supporter(self):
         if self.current_user is None:

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade
@@ -1,0 +1,25 @@
+ul
+  li
+    a.department(
+      href = propositions_badge_url(department_name)
+      title = _("department")
+    )= department_name
+
+  li
+    a.area(
+      href = propositions_badge_url(department_name, subject_area_name)
+      title = _("subject_area")
+    )= subject_area_name
+
+  for tag in tags
+    li
+      a.tag(
+        href = propositions_badge_url(
+          department_name, subject_area_name, tag.name
+        )
+        title = _("tag")
+      )= tag.name
+
+
+// generated from jade
+//- vim: set filetype=jade sw=2 ts=2 sts=2 expandtab:

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade
@@ -3,7 +3,9 @@
     = status()
 
   .proposition_body
-    = tag_list()
+
+    .proposition_badges
+      = badges()
 
     h4.proposition_title
         a(href=self_link)= full_title

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition_tag_list.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition_tag_list.j2.jade
@@ -1,8 +1,0 @@
-ul.list-inline
-  for tag in tags
-    li.list-inline-item
-      a(href=propositions_tag_url(tag))
-        span.tag_text= tag.name
-
-// generated from jade
-//- vim: set filetype=jade sw=2 ts=2 sts=2 expandtab:

--- a/src/ekklesia_portal/datamodel.py
+++ b/src/ekklesia_portal/datamodel.py
@@ -306,7 +306,7 @@ class Ballot(Base):  # conflicting qualified propositions
     proposition_type: PropositionType = relationship("PropositionType", back_populates="ballots")
 
     area_id: int = C(Integer, ForeignKey('subjectareas.id'))
-    area = relationship("SubjectArea", back_populates="ballots")  # contains department
+    area: SubjectArea = relationship("SubjectArea", back_populates="ballots")  # contains department
 
     # optional, if assigned, set proposition to planned
     voting_id: int = C(Integer, ForeignKey('votingphases.id'))

--- a/src/ekklesia_portal/sass/portal.sass
+++ b/src/ekklesia_portal/sass/portal.sass
@@ -436,10 +436,27 @@ ul.proposition_filter
 hr.argument_separator
   border-top: 2px solid $light
 
-span.tag_text
-  @extend .badge
-  @extend .badge-secondary
-  margin-left: 0.5rem
+.proposition_badges
+  ul
+    @extend .list-inline
+
+  li
+    @extend .list-inline-item
+
+  .badge
+    padding: 0.4em 0.6em
+
+  .department
+    @extend .badge-primary
+    @extend .badge
+
+  .area
+    @extend .badge-secondary
+    @extend .badge
+
+  .tag
+    @extend .badge-light
+    @extend .badge
 
 .top_navbar
   @extend .navbar

--- a/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-02 16:13+0000\n"
+"POT-Creation-Date: 2022-06-24 02:11+0200\n"
 "PO-Revision-Date: 2015-09-06 22:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -106,6 +106,7 @@ msgstr "Ergebnis"
 #: src/ekklesia_portal/concepts/document/document_contracts.py:11
 #: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:7
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:4
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:15
 #: src/ekklesia_portal/concepts/subject_area/templates/subject_area.j2.jade:3
 #: src/ekklesia_portal/concepts/subject_area/templates/subject_area.j2.jade:5
@@ -188,6 +189,7 @@ msgstr "Anzahl der Anträge"
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:3
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:5
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:5
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:2
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:13
 #: src/ekklesia_portal/concepts/subject_area/subject_area_contracts.py:10
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:15
@@ -770,7 +772,11 @@ msgstr "Melden"
 msgid "note_button"
 msgstr "Notizen"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:10
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:8
+msgid "tag"
+msgstr "Schlagwort (Tag)"
+
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:12
 msgid "title_motivation"
 msgstr "Begründung"
 

--- a/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-02 16:13+0000\n"
+"POT-Creation-Date: 2022-06-24 02:11+0200\n"
 "PO-Revision-Date: 2015-09-06 22:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -106,6 +106,7 @@ msgstr "result"
 #: src/ekklesia_portal/concepts/document/document_contracts.py:11
 #: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:7
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:4
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:15
 #: src/ekklesia_portal/concepts/subject_area/templates/subject_area.j2.jade:3
 #: src/ekklesia_portal/concepts/subject_area/templates/subject_area.j2.jade:5
@@ -188,6 +189,7 @@ msgstr "Number of propositions"
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:3
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:5
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:5
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:2
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:13
 #: src/ekklesia_portal/concepts/subject_area/subject_area_contracts.py:10
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:15
@@ -769,7 +771,11 @@ msgstr "Report"
 msgid "note_button"
 msgstr "Notes"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:10
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:8
+msgid "tag"
+msgstr "Tag"
+
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:12
 msgid "title_motivation"
 msgstr "Motivation"
 
@@ -1772,4 +1778,3 @@ msgstr "Abstention"
 #~ msgid_plural "propositions"
 #~ msgstr[0] "proposition"
 #~ msgstr[1] "propositions"
-


### PR DESCRIPTION
Department and area are displayed as badges now, like special kinds of tags.

Clicking on a department filters by department and clicking on the area
filters by department and subject area (area is always bound to a
department).

Clicking on a tag now behaves differently: it also filters by department
and subject area as this will be the most common use case: see other
propositions about the same topic, in the same subject area.
Searching for topics globally is generally less helpful but still possible by
removing the department filter with another click.

#91