### PR TITLE
Proposition: rework "change propositions" into amendments

### DIFF
--- a/src/ekklesia_portal/app.py
+++ b/src/ekklesia_portal/app.py
@@ -37,7 +37,7 @@ def app_setting_section():
         "default_proposition_query": {
             "status": "draft,submitted,qualified,scheduled,voting"
         },
-        "enable_change_propositions": True,
+        "enable_amendments": True,
         "enable_counter_propositions": True,
         "fallback_language": "de",
         "faq_url": None,

--- a/src/ekklesia_portal/concepts/proposition/proposition_contracts.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_contracts.py
@@ -8,17 +8,14 @@ from ekklesia_common.translation import _
 from ekklesia_portal.enums import PropositionRelationType, PropositionStatus, PropositionVisibility
 
 
-def common_widgets(items_for_selects):
-    return {
-        'title': TextAreaWidget(rows=2),
-        'abstract': TextAreaWidget(rows=4),
-        'content': TextAreaWidget(rows=8),
-        'motivation': TextAreaWidget(rows=8),
-        'tags': Select2Widget(multiple=True, tags=True, values=items_for_selects['tags']),
-        'relation_type': HiddenWidget(),
-        'related_proposition_id': HiddenWidget()
-    }
-
+common_widgets = {
+    'title': TextAreaWidget(rows=2),
+    'abstract': TextAreaWidget(rows=4),
+    'content': TextAreaWidget(rows=8),
+    'motivation': TextAreaWidget(rows=8),
+    'relation_type': HiddenWidget(),
+    'related_proposition_id': HiddenWidget()
+}
 
 class PropositionSchema(Schema):
     title = string_property(title=_('title'), validator=Length(min=5, max=255))
@@ -76,7 +73,8 @@ class PropositionNewForm(Form):
             'editing_remarks': TextAreaWidget(rows=4),
             'area_id': Select2Widget(values=items_for_selects['area']),
             'proposition_type_id': Select2Widget(values=items_for_selects['proposition_type']),
-            **common_widgets(items_for_selects)
+            'tags': Select2Widget(multiple=True, tags=True, values=items_for_selects['tags']),
+            **common_widgets
         })
 
 
@@ -90,7 +88,8 @@ class PropositionEditForm(Form):
             'status': SelectWidget(values=items_for_selects['status']),
             'visibility': SelectWidget(values=items_for_selects['visibility']),
             'external_fields': TextAreaWidget(rows=4),
-            **common_widgets(items_for_selects)
+            'tags': Select2Widget(multiple=True, tags=True, values=items_for_selects['tags']),
+            **common_widgets
         })
 
 
@@ -109,7 +108,7 @@ class PropositionNewDraftForm(Form):
             'abstract': common['abstract'],
             'content': common['content'],
             'motivation': common['motivation'],
-            'tags': common['tags']
+            'tags': Select2Widget(multiple=True, tags=True, values=items_for_selects['tags']),
         })
 
 
@@ -119,4 +118,18 @@ class PropositionSubmitDraftForm(Form):
         super().__init__(PropositionSchema(), request, action, buttons=[Button(title=_("button_submit_draft"))])
 
     def prepare_for_render(self, items_for_selects):
-        self.set_widgets(common_widgets(items_for_selects))
+        self.set_widgets({
+            'tags': Select2Widget(multiple=True, tags=True, values=items_for_selects['tags']),
+            **common_widgets
+        })
+
+
+class PropositionNewAmendmentForm(Form):
+    def __init__(self, request, action):
+        super().__init__(PropositionSchema(), request, action, buttons=[Button(title=_("submit"))])
+
+    def prepare_for_render(self):
+        self.set_widgets({
+            "tags": HiddenWidget(),
+            **common_widgets
+        })

--- a/src/ekklesia_portal/concepts/proposition/propositions.py
+++ b/src/ekklesia_portal/concepts/proposition/propositions.py
@@ -28,8 +28,7 @@ class Propositions:
     without_tags: str = None
     type: str = None
     visibility: str = None
-    association_type: PropositionRelationType = None
-    association_id: str = None
+    include_amendments: str = None
     # Initialization with numbers instead of None is necessary because otherwise the
     # query values are not actually converted to an integer on assignment
     page: Optional[int] = 1  # Ranges: x<=1 = None => First page; x>1 => Show page x
@@ -49,6 +48,7 @@ class Propositions:
         self.without_tags = self.without_tags or None
         self.type = self.type or None
         self.status = self.status or None
+        self.include_amendments = self.include_amendments or None
 
         self.status_values = None
         self.tag_values = None
@@ -159,6 +159,8 @@ class Propositions:
                 self.section = value
             case "visibility":
                 self.visibility = value
+            case "include_amendments":
+                self.include_amendments = value
 
     def build_search_query(self):
         query = []
@@ -184,6 +186,8 @@ class Propositions:
             query.append("section:" + self.maybe_add_quotes(self.section))
         if self.visibility:
             query.append("visibility:" + self.maybe_add_quotes(self.visibility))
+        if self.include_amendments:
+            query.append("include_amendments:" + self.include_amendments)
 
         return " ".join(query)
 
@@ -267,6 +271,9 @@ class Propositions:
             tags = q(Tag).filter(func.lower(Tag.name).in_(self.without_tag_values)).all()
             for tag in tags:
                 propositions = propositions.filter(~Proposition.tags.contains(tag))
+
+        if not self.include_amendments:
+                propositions = propositions.filter(Proposition.modifies_id.is_(None))
 
         if count:
             propositions = propositions.count()

--- a/src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade
@@ -1,0 +1,18 @@
+- extends "ekklesia_portal/layout.j2.jade"
+
+- block title
+  title= _("title_new_amendment")
+
+- block content
+  h2= _("title_new_amendment")
+  h3
+    = _("changes_proposition")
+    |:&nbsp;
+    a(href=self_link)= title
+
+  .help-text
+    = new_amendment_explanation|markdown
+
+  = form_html
+
+//- vim: set filetype=jade sw=2 ts=2 sts=2 expandtab:

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade
@@ -55,28 +55,28 @@
         .row.arguments
           a(name="bottom")
 
-          .proposition_col.change
+          .proposition_col.amendments
 
             if modifies
-              .proposition_change_header
+              .proposition_amendments_header
                 .card-body
                   h4= _('title_proposition_modifies')
 
-              = render_cell(modifies, 'small', side='left')
+                  = render_cell(modifies, 'small', side='left')
 
 
             if derivations
-              .proposition_change_header
+              .proposition_amendments_header
                 .card-body
-                  h4= _('title_proposition_derivations')
+                  h4= _('title_amendments')
 
-            = render_cell(collection=derivations, view_name='small', side='left')
+                = render_cell(collection=derivations, view_name='small', side='left')
 
-            if show_create_associated_proposition
-              a(href=new_associated_proposition_url("change"))
+            if show_create_amendment
+              a(href=new_amendment_url)
                 .button_add_related
                   i.far.fa-circle &nbsp;
-                  = _("button_add_change_proposition")
+                  = _("button_add_amendment")
 
           .proposition_col.counter
 
@@ -94,11 +94,11 @@
 
             = render_cell(collection=replacements, view_name='small', side='right')
 
-            if show_create_associated_proposition
-              a(href=new_associated_proposition_url("counter"))
-                .button_add_related
-                  i.fas.fa-circle &nbsp;
-                  = customizable_text("button_add_counter_proposition")
+        if show_create_counter_proposition
+          a(href=new_counter_proposition_url)
+            .button_add_related
+              i.fas.fa-circle &nbsp;
+              = customizable_text("button_add_counter_proposition")
 
 // generated from jade
 //- vim: set filetype=jade sw=2 ts=2 sts=2 expandtab:

--- a/src/ekklesia_portal/sass/portal.sass
+++ b/src/ekklesia_portal/sass/portal.sass
@@ -84,7 +84,7 @@ $light-violet: lighten($violet, 50%)
   @extend .mt-1
   @extend .row
 
-.con, .change
+.con, .amendments
   .authoring_info
     @extend .text-right
 
@@ -276,7 +276,7 @@ footer.footer
   @extend .nav-tabs
   @extend .card-header-tabs
 
-.proposition_change_header
+.proposition_amendments_header
   @extend .card
   border: 0
 

--- a/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-24 02:11+0200\n"
+"POT-Creation-Date: 2022-06-28 20:53+0200\n"
 "PO-Revision-Date: 2015-09-06 22:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -20,15 +20,15 @@ msgstr ""
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:12
 #: src/ekklesia_portal/concepts/page/page_contracts.py:11
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:24
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:21
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:51
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:12
 msgid "title"
 msgstr "Titel"
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:13
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:28
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:58
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
 msgid "abstract"
 msgstr "Zusammenfassung"
 
@@ -45,7 +45,8 @@ msgstr "Ausführlich"
 #: src/ekklesia_portal/concepts/ekklesia_portal/contracts/token.py:14
 #: src/ekklesia_portal/concepts/page/page_contracts.py:19
 #: src/ekklesia_portal/concepts/policy/policy_contracts.py:30
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:86
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:84
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:129
 #: src/ekklesia_portal/concepts/proposition_note/proposition_note_contracts.py:20
 #: src/ekklesia_portal/concepts/proposition_type/proposition_type_contracts.py:18
 #: src/ekklesia_portal/concepts/subject_area/subject_area_contracts.py:17
@@ -104,7 +105,7 @@ msgstr "Ergebnis"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:14
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:21
 #: src/ekklesia_portal/concepts/document/document_contracts.py:11
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:31
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:7
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:4
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:15
@@ -122,7 +123,7 @@ msgstr "Abstimmungszeitraum"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:16
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:23
 #: src/ekklesia_portal/concepts/document/templates/document.j2.jade:15
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:32
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:17
 #: src/ekklesia_portal/concepts/proposition_type/templates/proposition_type.j2.jade:3
 msgid "proposition_type"
@@ -635,72 +636,76 @@ msgstr "Regelwerk"
 msgid "days"
 msgstr "Tage"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:22
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:52
 msgid "content"
 msgstr "Text"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:26
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:56
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:23
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:53
 msgid "motivation"
 msgstr "Begründung"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:27
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:57
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:24
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
 msgid "tags"
 msgstr "Tags"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:37
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:60
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:57
 msgid "editing_remarks"
 msgstr "Anmerkungen zur Antragsentwicklung"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:38
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:61
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:58
 msgid "editing_remarks_description"
 msgstr ""
 "Hier kannst du z.B. angeben, welche Gruppe am Antrag arbeitet und wie "
 "Andere Verbesserungen einbringen können. Wird in der Antragsentwicklung "
 "vor dem Antrag eingefügt."
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:45
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:42
 msgid "voting_identifier"
 msgstr "Kennung für Abstimmung"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:46
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:43
 msgid "submitter_invitation_key"
 msgstr "Einladungs-Schlüssel für Antragsteller"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:44
 msgid "external_discussion_url"
 msgstr "Link zur Diskussion"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:48
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:45
 msgid "status"
 msgstr "Status"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:49
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:46
 #: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:35
 msgid "visibility"
 msgstr "Sichtbarkeit"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:50
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
 msgid "external_fields"
 msgstr "Daten für externe Systeme"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:72
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:100
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:69
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:99
 msgid "button_create_draft"
 msgstr "Antragsentwurf anlegen"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:119
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:118
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:2
 msgid "button_submit_draft"
 msgstr "Antrag einreichen"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_views.py:378
+#: src/ekklesia_portal/concepts/proposition/proposition_views.py:392
 msgid "change"
 msgstr "Änderung"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_views.py:502
+msgid "amendment_to"
+msgstr "Änderungsantrag to %(title)s"
 
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:2
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:3
@@ -723,6 +728,15 @@ msgstr "Ziel für Export"
 msgid "push_draft_button"
 msgstr "Antragsentwurf übertragen"
 
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade:3
+msgid "title_new_amendment"
+msgstr "Neuer Änderungsantrag"
+
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade:4
+msgid "changes_proposition"
+msgstr "Ändert"
+
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:6
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_toolbar.j2.jade:2
 msgid "tab_discussion"
@@ -741,11 +755,11 @@ msgid "title_proposition_modifies"
 msgstr "Ist Änderungsantrag zu"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:34
-msgid "title_proposition_derivations"
+msgid "title_amendments"
 msgstr "Änderungsanträge"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:37
-msgid "button_add_change_proposition"
+msgid "button_add_amendment"
 msgstr "Änderungsantrag stellen"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:43
@@ -1742,7 +1756,7 @@ msgstr "Änderungsantrag für:"
 #~ msgid "association_type"
 #~ msgstr "Beziehungstyp"
 
-#~ msgid "change_proposition"
+#~ msgid "amendment"
 #~ msgstr "Änderungsantrag"
 
 #~ msgid "counter_proposition"
@@ -1824,4 +1838,3 @@ msgstr "Änderungsantrag für:"
 #~ msgid_plural "propositions"
 #~ msgstr[0] "Antrag"
 #~ msgstr[1] "Anträge"
-

--- a/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-24 02:11+0200\n"
+"POT-Creation-Date: 2022-06-28 20:53+0200\n"
 "PO-Revision-Date: 2015-09-06 22:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -20,15 +20,15 @@ msgstr ""
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:12
 #: src/ekklesia_portal/concepts/page/page_contracts.py:11
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:24
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:21
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:51
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:12
 msgid "title"
 msgstr "Title"
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:13
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:28
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:58
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
 msgid "abstract"
 msgstr "Abstract"
 
@@ -45,7 +45,8 @@ msgstr "Details"
 #: src/ekklesia_portal/concepts/ekklesia_portal/contracts/token.py:14
 #: src/ekklesia_portal/concepts/page/page_contracts.py:19
 #: src/ekklesia_portal/concepts/policy/policy_contracts.py:30
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:86
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:84
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:129
 #: src/ekklesia_portal/concepts/proposition_note/proposition_note_contracts.py:20
 #: src/ekklesia_portal/concepts/proposition_type/proposition_type_contracts.py:18
 #: src/ekklesia_portal/concepts/subject_area/subject_area_contracts.py:17
@@ -104,7 +105,7 @@ msgstr "result"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:14
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:21
 #: src/ekklesia_portal/concepts/document/document_contracts.py:11
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:31
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:7
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_badges.j2.jade:4
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:15
@@ -122,7 +123,7 @@ msgstr "Voting phase"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:16
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:23
 #: src/ekklesia_portal/concepts/document/templates/document.j2.jade:15
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:32
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:17
 #: src/ekklesia_portal/concepts/proposition_type/templates/proposition_type.j2.jade:3
 msgid "proposition_type"
@@ -635,71 +636,75 @@ msgstr "Policy"
 msgid "days"
 msgstr "days"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:22
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:52
 msgid "content"
 msgstr "Content"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:26
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:56
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:23
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:53
 msgid "motivation"
 msgstr "Motivation"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:27
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:57
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:24
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
 msgid "tags"
 msgstr "Tags"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:37
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:60
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:57
 msgid "editing_remarks"
 msgstr "Editing remarks"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:38
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:61
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:58
 msgid "editing_remarks_description"
 msgstr ""
 "You can say here, for example, which group is working on the proposition "
 "and how to submit improvements."
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:45
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:42
 msgid "voting_identifier"
 msgstr "Identifier for voting"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:46
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:43
 msgid "submitter_invitation_key"
 msgstr ""
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:44
 msgid "external_discussion_url"
 msgstr "Link to discussion"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:48
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:45
 msgid "status"
 msgstr "Status"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:49
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:46
 #: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:35
 msgid "visibility"
 msgstr "Visibility"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:50
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
 msgid "external_fields"
 msgstr "Data for external systems"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:72
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:100
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:69
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:99
 msgid "button_create_draft"
 msgstr "Create Draft"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:119
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:118
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:2
 msgid "button_submit_draft"
 msgstr "Submit Proposition"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_views.py:378
+#: src/ekklesia_portal/concepts/proposition/proposition_views.py:392
 msgid "change"
 msgstr "Change"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_views.py:502
+msgid "amendment_to"
+msgstr "Amendment to %(title)s"
 
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:2
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:3
@@ -722,6 +727,15 @@ msgstr "Export target"
 msgid "push_draft_button"
 msgstr "Push draft"
 
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade:3
+msgid "title_new_amendment"
+msgstr "New Proposition Amendment"
+
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition_amendment.j2.jade:4
+msgid "changes_proposition"
+msgstr "Changes"
+
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:6
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_toolbar.j2.jade:2
 msgid "tab_discussion"
@@ -737,15 +751,15 @@ msgstr "Add Contra Argument"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:29
 msgid "title_proposition_modifies"
-msgstr "Is Change Motion For"
+msgstr "Is Amendment For"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:34
-msgid "title_proposition_derivations"
-msgstr "Change Motions"
+msgid "title_amendments"
+msgstr "Amendments"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:37
-msgid "button_add_change_proposition"
-msgstr "Add Change Motion"
+msgid "button_add_amendment"
+msgstr "Add Amendment"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:43
 msgid "title_proposition_replaces"
@@ -1718,7 +1732,7 @@ msgstr "Change motion for:"
 #~ msgid "association_type"
 #~ msgstr "Relation type"
 
-#~ msgid "change_proposition"
+#~ msgid "amendment"
 #~ msgstr "change motion"
 
 #~ msgid "counter_proposition"


### PR DESCRIPTION
Change propositions existed for a longer time but were not actually that useful. Amendments are seen as dependent on the original proposition so we don't show them in the proposition list by default, for example. The search filter include_amendments can be used to show them.

Closes #113